### PR TITLE
Change `:s-vars` in schemes to a vector of maps for easier extension

### DIFF
--- a/src/erp12/schema_inference/api.clj
+++ b/src/erp12/schema_inference/api.clj
@@ -1,28 +1,7 @@
 (ns erp12.schema-inference.api
-  (:require [erp12.schema-inference.impl.algo_w :as algo-w]
-            [erp12.schema-inference.impl.util :as u]))
+  (:require [erp12.schema-inference.impl.algo_w :as algo-w]))
 
 (defn infer-schema
   "Infer the schema of the expression given the environment."
   [ast env]
   (algo-w/infer-schema ast env))
-
-(defn concretize
-  [bindings {:keys [type] :as schema}]
-  (let [schema (if (= type :scheme) (:body schema) schema)]
-    (->> schema
-         (u/substitute bindings)
-         (u/generalize {}))))
-
-
-(comment
-
-  (concretize {'T {:type 'int?}}
-              {:type   :scheme
-               :s-vars ['T]
-               :body   {:type   :=>
-                        :input  {:type     :cat
-                                 :children [{:type :s-var, :sym 'T}]}
-                        :output {:type :s-var, :sym 'T}}})
-
-  )

--- a/test/erp12/schema_inference/impl/algo_w_test.clj
+++ b/test/erp12/schema_inference/impl/algo_w_test.clj
@@ -24,7 +24,7 @@
 
    'clojure.core/if
    {:type   :scheme
-    :s-vars ['a]
+    :s-vars [{:sym 'a}]
     :body   {:type   :=>
              :input  {:type     :cat
                       :children [{:type 'boolean?}
@@ -34,7 +34,7 @@
 
    'clojure.core/map
    {:type   :scheme
-    :s-vars ['a 'b]
+    :s-vars [{:sym 'a} {:sym 'b}]
     :body   {:type   :=>
              :input  {:type     :cat
                       :children [{:type   :=>
@@ -69,7 +69,7 @@
         (algo-w (ana/analyze `(fn [x#] (f (inc x#) 1)))
                 (assoc test-env
                   `f {:type   :scheme
-                      :s-vars ['a]
+                      :s-vars [{:sym 'a}]
                       :body   {:type   :=>
                                :input  {:type     :cat
                                         :children [{:type :s-var :sym 'a}
@@ -92,7 +92,7 @@
           (algo-w (ana/analyze `(fn [x# y#] (f x# y#)))
                   (assoc test-env
                     `f {:type   :scheme
-                        :s-vars ['a 'b]
+                        :s-vars [{:sym 'a} {:sym 'b}]
                         :body   {:type   :=>
                                  :input  {:type     :cat
                                           :children [{:type :s-var :sym 'a}

--- a/test/erp12/schema_inference/impl/util_test.clj
+++ b/test/erp12/schema_inference/impl/util_test.clj
@@ -12,7 +12,7 @@
                                 :children [{:type 'int?}]}
                        :output {:type 'float?}})))
   (is (not (u/ground? {:type   :scheme
-                       :s-vars ['x]
+                       :s-vars [{:sym 'x}]
                        :body   {:type   :=>
                                 :input  {:type     :cat
                                          :children [{:type 'int?}]}
@@ -38,35 +38,35 @@
                     :output {:type :s-var :sym 'x}}))))
     (testing "scheme"
       (is (= {:type   :scheme
-              :s-vars ['z]
+              :s-vars [{:sym 'z}]
               :body   {:type :s-var :sym 'y}}
              (x->y {:type   :scheme
-                    :s-vars ['z]
+                    :s-vars [{:sym 'z}]
                     :body   {:type :s-var :sym 'x}})))
       ;; Occurs check
       (is (= {:type   :scheme
-              :s-vars ['x]
+              :s-vars [{:sym 'x}]
               :body   {:type :s-var :sym 'x}}
              (x->y {:type   :scheme
-                    :s-vars ['x]
+                    :s-vars [{:sym 'x}]
                     :body   {:type :s-var :sym 'x}}))))))
 
 (deftest substitute-env-test
   (is {'a {:type   :scheme
-           :s-vars ['z]
+           :s-vars [{:sym 'z}]
            :body   {:type  :vector
                     :child {:type :s-var :sym 'y}}}
        'b {:type   :scheme
-           :s-vars ['x]
+           :s-vars [{:sym 'x}]
            :body   {:type  :set
                     :child {:type :s-var :sym 'x}}}}
       (u/substitute-env {'x {:type :s-var :sym 'y}}
                         {'a {:type   :scheme
-                             :s-vars ['z]
+                             :s-vars [{:sym 'z}]
                              :body   {:type  :vector
                                       :child {:type :s-var :sym 'x}}}
                          'b {:type   :scheme
-                             :s-vars ['x]
+                             :s-vars [{:sym 'x}]
                              :body   {:type  :set
                                       :child {:type :s-var :sym 'x}}}})))
 
@@ -101,14 +101,14 @@
   (testing "scheme"
     (is (= #{'y}
            (u/free-type-vars {:type   :scheme
-                              :s-vars ['x]
+                              :s-vars [{:sym 'x}]
                               :body   {:type   :=>
                                        :input  {:type     :cat
                                                 :children [{:type :s-var :sym 'x}]}
                                        :output {:type :s-var :sym 'y}}})))
     (is (= #{}
            (u/free-type-vars {:type   :scheme
-                              :s-vars ['x 'y]
+                              :s-vars [{:sym 'x} {:sym 'y}]
                               :body   {:type   :=>
                                        :input  {:type     :cat
                                                 :children [{:type :s-var :sym 'x}]}
@@ -116,11 +116,11 @@
 
 (deftest free-type-vars-env-test
   (is (= (u/free-type-vars-env {'a {:type   :scheme
-                                    :s-vars ['z]
+                                    :s-vars [{:sym 'z}]
                                     :body   {:type  :vector
                                              :child {:type :s-var :sym 'x}}}
                                 'b {:type   :scheme
-                                    :s-vars ['x]
+                                    :s-vars [{:sym 'x}]
                                     :body   {:type  :set
                                              :child {:type :s-var :sym 'x}}}})
          #{'x})))
@@ -131,7 +131,7 @@
   (is (= (u/instantiate {:type :s-var :sym 'x})
          {:type :s-var :sym 'x}))
   (let [s (u/instantiate {:type   :scheme
-                          :s-vars ['x]
+                          :s-vars [{:sym 'x}]
                           :body   {:type  :vector
                                    :child {:type :s-var :sym 'x}}})]
     (is (= (:type s) :vector))
@@ -146,7 +146,7 @@
     (is (= {:type :s-var :sym 'x}
            (u/generalize env {:type :s-var :sym 'x})))
     (is (= {:type   :scheme
-            :s-vars ['y]
+            :s-vars [{:sym 'y}]
             :body   {:type  :vector
                      :child {:type :s-var :sym 'y}}}
            (u/generalize env


### PR DESCRIPTION
Making `:s-vars` a vector of maps allows us to extend the maps to add additional context about the type variable, such as various kinds of constraints. This will allow future work into features such as type classes, type bounds, co- and contra-variance, and row types. 

This is a breaking change which provides no additional functional benefit. Dependents will need to update all of their polymorphic annotations to use the new syntax.